### PR TITLE
Remove help at stsci email from pyproject.toml authors list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "jwst_novt"
 description = "JWST NIRSpec Observation Visualization Tool"
-authors = [{name = "STScI", email = "help@stsci.edu"}]
+authors = [{name = "STScI"}]
 license = {file = "LICENSE.rst"}
 dynamic = ["version"]
 requires-python = ">=3.9"


### PR DESCRIPTION
Closes #13 

This PR removes the `help[at]stsci` email from pyproject.toml authors list.